### PR TITLE
Major bug fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Psi4FockCI
 
-<img src="https://travis-ci.com/shannonhouck/psi4_spinflip_wfn.svg?token=yXoAYb1Qe6BWq8AUXzXG&branch=master">
+<img src="https://travis-ci.com/shannonhouck/psi4fockci.svg?branch=master">
 
 Code Author: Shannon E. Houck
 

--- a/psi4fockci/spinflip.py
+++ b/psi4fockci/spinflip.py
@@ -73,6 +73,7 @@ def sf_cas( new_charge, new_multiplicity, ref_mol, conf_space="", add_opts={},
     opts = {'scf_type': 'pk',
             'basis': 'cc-pvdz',
             'reference': 'rohf',
+            'mixed': False,
             'maxiter': 1000,
             'ci_maxiter': 50 }
     opts.update(add_opts) # add additional options from user


### PR DESCRIPTION
Realized after running some benchmarks that allowing the "mixed" default to be "true" resulted in an incorrect number of states included in the calculation for some cases. This was changed several months back because I thought it was an unnecessary keyword; since it wasn't, this changes the default back.